### PR TITLE
Add comprehensive OpenAPI documentation to missing API controllers

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/EventCategoryController.php
+++ b/backend/app/Http/Controllers/Api/V1/EventCategoryController.php
@@ -11,10 +11,91 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Carbon\Carbon;
 
+/**
+ * @OA\Tag(
+ *     name="Event Categories",
+ *     description="API Endpoints for event category management"
+ * )
+ */
 class EventCategoryController extends Controller
 {
     /**
      * Display a listing of event categories
+     * 
+     * @OA\Get(
+     *     path="/api/v1/event-categories",
+     *     summary="Get all event categories",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="is_active",
+     *         in="query",
+     *         description="Filter by active status",
+     *         required=false,
+     *         @OA\Schema(type="boolean")
+     *     ),
+     *     @OA\Parameter(
+     *         name="is_recurring",
+     *         in="query",
+     *         description="Filter by recurring status",
+     *         required=false,
+     *         @OA\Schema(type="boolean")
+     *     ),
+     *     @OA\Parameter(
+     *         name="attendance_type",
+     *         in="query",
+     *         description="Filter by attendance type",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"individual","general","none"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="search",
+     *         in="query",
+     *         description="Search by name or description",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Event categories retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="Sunday Service"),
+     *                     @OA\Property(property="description", type="string", example="Weekly worship service"),
+     *                     @OA\Property(property="color", type="string", example="#FF5733"),
+     *                     @OA\Property(property="icon", type="string", example="church"),
+     *                     @OA\Property(property="attendance_type", type="string", example="individual"),
+     *                     @OA\Property(property="is_active", type="boolean", example=true),
+     *                     @OA\Property(property="is_recurring", type="boolean", example=true),
+     *                     @OA\Property(property="recurrence_pattern", type="string", example="weekly"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time")
+     *                 )),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=15),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request): JsonResponse
     {
@@ -58,6 +139,82 @@ class EventCategoryController extends Controller
 
     /**
      * Store a newly created event category
+     * 
+     * @OA\Post(
+     *     path="/api/v1/event-categories",
+     *     summary="Create a new event category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name","attendance_type"},
+     *             @OA\Property(property="name", type="string", example="Sunday Service", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Weekly worship service", description="Category description"),
+     *             @OA\Property(property="color", type="string", example="#FF5733", description="Category color"),
+     *             @OA\Property(property="icon", type="string", example="church", description="Category icon"),
+     *             @OA\Property(property="attendance_type", type="string", enum={"individual","general","none"}, example="individual", description="Type of attendance tracking"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Is category active"),
+     *             @OA\Property(property="is_recurring", type="boolean", example=true, description="Is category recurring"),
+     *             @OA\Property(property="recurrence_pattern", type="string", enum={"daily","weekly","monthly","yearly"}, example="weekly", description="Recurrence pattern"),
+     *             @OA\Property(property="recurrence_settings", type="object", description="Recurrence settings"),
+     *             @OA\Property(property="default_start_time", type="string", example="10:00:00", description="Default start time"),
+     *             @OA\Property(property="default_duration", type="integer", example=120, description="Default duration in minutes"),
+     *             @OA\Property(property="start_date_time", type="string", example="2024-01-01 10:00:00", description="Start date time for one-time events"),
+     *             @OA\Property(property="end_date_time", type="string", example="2024-01-01 12:00:00", description="End date time for one-time events"),
+     *             @OA\Property(property="recurrence_start_date", type="string", example="2024-01-01", description="Recurrence start date"),
+     *             @OA\Property(property="recurrence_end_date", type="string", example="2024-12-31", description="Recurrence end date"),
+     *             @OA\Property(property="default_location", type="string", example="Main Hall", description="Default location"),
+     *             @OA\Property(property="default_description", type="string", example="Default event description", description="Default event description")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Event category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Event category created successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Sunday Service"),
+     *                 @OA\Property(property="description", type="string", example="Weekly worship service"),
+     *                 @OA\Property(property="color", type="string", example="#FF5733"),
+     *                 @OA\Property(property="icon", type="string", example="church"),
+     *                 @OA\Property(property="attendance_type", type="string", example="individual"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_recurring", type="boolean", example=true),
+     *                 @OA\Property(property="recurrence_pattern", type="string", example="weekly"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to create event category"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request): JsonResponse
     {
@@ -126,6 +283,55 @@ class EventCategoryController extends Controller
 
     /**
      * Display the specified event category
+     * 
+     * @OA\Get(
+     *     path="/api/v1/event-categories/{category}",
+     *     summary="Get a specific event category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Event category retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Sunday Service"),
+     *                 @OA\Property(property="description", type="string", example="Weekly worship service"),
+     *                 @OA\Property(property="color", type="string", example="#FF5733"),
+     *                 @OA\Property(property="icon", type="string", example="church"),
+     *                 @OA\Property(property="attendance_type", type="string", example="individual"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_recurring", type="boolean", example=true),
+     *                 @OA\Property(property="recurrence_pattern", type="string", example="weekly"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     )
+     * )
      */
     public function show(EventCategory $category): JsonResponse
     {
@@ -139,6 +345,97 @@ class EventCategoryController extends Controller
 
     /**
      * Update the specified event category
+     * 
+     * @OA\Put(
+     *     path="/api/v1/event-categories/{category}",
+     *     summary="Update an event category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name","attendance_type"},
+     *             @OA\Property(property="name", type="string", example="Sunday Service", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Weekly worship service", description="Category description"),
+     *             @OA\Property(property="color", type="string", example="#FF5733", description="Category color"),
+     *             @OA\Property(property="icon", type="string", example="church", description="Category icon"),
+     *             @OA\Property(property="attendance_type", type="string", enum={"individual","general","none"}, example="individual", description="Type of attendance tracking"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Is category active"),
+     *             @OA\Property(property="is_recurring", type="boolean", example=true, description="Is category recurring"),
+     *             @OA\Property(property="recurrence_pattern", type="string", enum={"daily","weekly","monthly","yearly"}, example="weekly", description="Recurrence pattern"),
+     *             @OA\Property(property="recurrence_settings", type="object", description="Recurrence settings"),
+     *             @OA\Property(property="default_start_time", type="string", example="10:00:00", description="Default start time"),
+     *             @OA\Property(property="default_duration", type="integer", example=120, description="Default duration in minutes"),
+     *             @OA\Property(property="start_date_time", type="string", example="2024-01-01 10:00:00", description="Start date time for one-time events"),
+     *             @OA\Property(property="end_date_time", type="string", example="2024-01-01 12:00:00", description="End date time for one-time events"),
+     *             @OA\Property(property="recurrence_start_date", type="string", example="2024-01-01", description="Recurrence start date"),
+     *             @OA\Property(property="recurrence_end_date", type="string", example="2024-12-31", description="Recurrence end date"),
+     *             @OA\Property(property="default_location", type="string", example="Main Hall", description="Default location"),
+     *             @OA\Property(property="default_description", type="string", example="Default event description", description="Default event description")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Event category updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Event category updated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Sunday Service"),
+     *                 @OA\Property(property="description", type="string", example="Weekly worship service"),
+     *                 @OA\Property(property="color", type="string", example="#FF5733"),
+     *                 @OA\Property(property="icon", type="string", example="church"),
+     *                 @OA\Property(property="attendance_type", type="string", example="individual"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_recurring", type="boolean", example=true),
+     *                 @OA\Property(property="recurrence_pattern", type="string", example="weekly"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to update event category"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, EventCategory $category): JsonResponse
     {
@@ -206,6 +503,60 @@ class EventCategoryController extends Controller
 
     /**
      * Remove the specified event category
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/event-categories/{category}",
+     *     summary="Delete an event category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Event category deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Event category deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Cannot delete category with events",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Cannot delete category with existing events. Please delete or reassign events first.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to delete event category"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function destroy(EventCategory $category): JsonResponse
     {
@@ -242,6 +593,80 @@ class EventCategoryController extends Controller
 
     /**
      * Get all events for a specific category
+     * 
+     * @OA\Get(
+     *     path="/api/v1/event-categories/{category}/events",
+     *     summary="Get events for a specific category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filter by event status",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="date_from",
+     *         in="query",
+     *         description="Filter by start date from",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="date_to",
+     *         in="query",
+     *         description="Filter by start date to",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category events retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="category", type="object"),
+     *                 @OA\Property(property="events", type="object",
+     *                     @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *                     @OA\Property(property="current_page", type="integer", example=1),
+     *                     @OA\Property(property="last_page", type="integer", example=1),
+     *                     @OA\Property(property="per_page", type="integer", example=15),
+     *                     @OA\Property(property="total", type="integer", example=1)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     )
+     * )
      */
     public function getCategoryEvents(Request $request, EventCategory $category): JsonResponse
     {
@@ -283,6 +708,73 @@ class EventCategoryController extends Controller
 
     /**
      * Generate events for a category based on recurrence settings
+     * 
+     * @OA\Post(
+     *     path="/api/v1/event-categories/{category}/generate-events",
+     *     summary="Generate recurring events for a category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="from_date", type="string", example="2024-01-01", description="Start date for generation"),
+     *             @OA\Property(property="count", type="integer", example=10, description="Number of events to generate"),
+     *             @OA\Property(property="auto_publish", type="boolean", example=false, description="Auto publish generated events")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Events generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="10 events generated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="category", type="object"),
+     *                 @OA\Property(property="generated_count", type="integer", example=10),
+     *                 @OA\Property(property="events", type="array", @OA\Items(type="object"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error or category not configured for recurring events",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="This category is not configured for recurring events")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to generate events"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function generateEvents(Request $request, EventCategory $category): JsonResponse
     {
@@ -358,6 +850,70 @@ class EventCategoryController extends Controller
 
     /**
      * Generate a single one-time event for a category
+     * 
+     * @OA\Post(
+     *     path="/api/v1/event-categories/{category}/generate-one-time-event",
+     *     summary="Generate a one-time event for a category",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="auto_publish", type="boolean", example=false, description="Auto publish generated event")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="One-time event generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="One-time event generated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="category", type="object"),
+     *                 @OA\Property(property="event", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error or category not suitable for one-time events",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="This category is configured for recurring events. Use generateEvents instead.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to generate one-time event"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function generateOneTimeEvent(Request $request, EventCategory $category): JsonResponse
     {
@@ -440,6 +996,53 @@ class EventCategoryController extends Controller
 
     /**
      * Toggle category active status
+     * 
+     * @OA\Post(
+     *     path="/api/v1/event-categories/{category}/toggle-status",
+     *     summary="Toggle category active status",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category status updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Category status updated successfully"),
+     *             @OA\Property(property="data", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to update category status"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function toggleStatus(EventCategory $category): JsonResponse
     {
@@ -466,6 +1069,62 @@ class EventCategoryController extends Controller
 
     /**
      * Get category statistics
+     * 
+     * @OA\Get(
+     *     path="/api/v1/event-categories/{category}/statistics",
+     *     summary="Get category statistics",
+     *     tags={"Event Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category statistics retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="total_events", type="integer", example=50),
+     *                 @OA\Property(property="published_events", type="integer", example=30),
+     *                 @OA\Property(property="draft_events", type="integer", example=15),
+     *                 @OA\Property(property="cancelled_events", type="integer", example=5),
+     *                 @OA\Property(property="upcoming_events", type="integer", example=10),
+     *                 @OA\Property(property="past_events", type="integer", example=40),
+     *                 @OA\Property(property="attendance_type", type="string", example="individual"),
+     *                 @OA\Property(property="is_recurring", type="boolean", example=true),
+     *                 @OA\Property(property="recurrence_pattern", type="string", example="weekly")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Failed to get category statistics"),
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function getStatistics(EventCategory $category): JsonResponse
     {

--- a/backend/app/Http/Controllers/Api/V1/ExpenseCategoryController.php
+++ b/backend/app/Http/Controllers/Api/V1/ExpenseCategoryController.php
@@ -6,8 +6,58 @@ use App\Http\Controllers\Controller;
 use App\Models\ExpenseCategory;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Expense Categories",
+ *     description="API Endpoints for expense category management"
+ * )
+ */
 class ExpenseCategoryController extends Controller
 {
+    /**
+     * Display a listing of expense categories
+     * 
+     * @OA\Get(
+     *     path="/api/v1/expense-categories",
+     *     summary="Get all expense categories",
+     *     tags={"Expense Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense categories retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Office Supplies"),
+     *                 @OA\Property(property="description", type="string", example="Office supplies and equipment"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=10),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
+     */
     public function index(Request $request)
     {
         $perPage = $request->input('per_page', 10);
@@ -23,6 +73,53 @@ class ExpenseCategoryController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created expense category
+     * 
+     * @OA\Post(
+     *     path="/api/v1/expense-categories",
+     *     summary="Create a new expense category",
+     *     tags={"Expense Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="Office Supplies", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Office supplies and equipment", description="Category description"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the category is active")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Expense category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Office Supplies"),
+     *             @OA\Property(property="description", type="string", example="Office supplies and equipment"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -34,12 +131,117 @@ class ExpenseCategoryController extends Controller
         return response()->json($category, 201);
     }
 
+    /**
+     * Display the specified expense category
+     * 
+     * @OA\Get(
+     *     path="/api/v1/expense-categories/{id}",
+     *     summary="Get a specific expense category",
+     *     tags={"Expense Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense category retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Office Supplies"),
+     *             @OA\Property(property="description", type="string", example="Office supplies and equipment"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense category not found")
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         $category = ExpenseCategory::findOrFail($id);
         return response()->json($category);
     }
 
+    /**
+     * Update the specified expense category
+     * 
+     * @OA\Put(
+     *     path="/api/v1/expense-categories/{id}",
+     *     summary="Update an expense category",
+     *     tags={"Expense Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="Office Supplies", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Office supplies and equipment", description="Category description"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the category is active")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense category updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Office Supplies"),
+     *             @OA\Property(property="description", type="string", example="Office supplies and equipment"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         $category = ExpenseCategory::findOrFail($id);
@@ -52,6 +254,45 @@ class ExpenseCategoryController extends Controller
         return response()->json($category);
     }
 
+    /**
+     * Remove the specified expense category
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/expense-categories/{id}",
+     *     summary="Delete an expense category",
+     *     tags={"Expense Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense category deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense category not found")
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         $category = ExpenseCategory::findOrFail($id);

--- a/backend/app/Http/Controllers/Api/V1/ExpenseController.php
+++ b/backend/app/Http/Controllers/Api/V1/ExpenseController.php
@@ -7,8 +7,62 @@ use App\Models\Expense;
 use App\Models\ExpenseCategory;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Expenses",
+ *     description="API Endpoints for expense management"
+ * )
+ */
 class ExpenseController extends Controller
 {
+    /**
+     * Display a listing of expenses
+     * 
+     * @OA\Get(
+     *     path="/api/v1/expenses",
+     *     summary="Get all expenses",
+     *     tags={"Expenses"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expenses retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="description", type="string", example="Office supplies"),
+     *                 @OA\Property(property="amount", type="number", example=150.00),
+     *                 @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15"),
+     *                 @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *                 @OA\Property(property="is_paid", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="category", type="object")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=10),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
+     */
     public function index(Request $request)
     {
         $perPage = $request->input('per_page', 10);
@@ -24,6 +78,60 @@ class ExpenseController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created expense
+     * 
+     * @OA\Post(
+     *     path="/api/v1/expenses",
+     *     summary="Create a new expense",
+     *     tags={"Expenses"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"category_id","amount","paid_date"},
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Expense category ID"),
+     *             @OA\Property(property="description", type="string", example="Office supplies", description="Expense description"),
+     *             @OA\Property(property="amount", type="number", example=150.00, description="Expense amount"),
+     *             @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15", description="Date when expense was paid"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20", description="Due date for payment"),
+     *             @OA\Property(property="is_paid", type="boolean", example=true, description="Whether the expense is paid")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Expense created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Office supplies"),
+     *             @OA\Property(property="amount", type="number", example=150.00),
+     *             @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_paid", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -38,12 +146,128 @@ class ExpenseController extends Controller
         return response()->json($expense->load('category'), 201);
     }
 
+    /**
+     * Display the specified expense
+     * 
+     * @OA\Get(
+     *     path="/api/v1/expenses/{id}",
+     *     summary="Get a specific expense",
+     *     tags={"Expenses"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Office supplies"),
+     *             @OA\Property(property="amount", type="number", example=150.00),
+     *             @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_paid", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense not found")
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         $expense = Expense::with('category')->findOrFail($id);
         return response()->json($expense);
     }
 
+    /**
+     * Update the specified expense
+     * 
+     * @OA\Put(
+     *     path="/api/v1/expenses/{id}",
+     *     summary="Update an expense",
+     *     tags={"Expenses"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Expense category ID"),
+     *             @OA\Property(property="description", type="string", example="Office supplies", description="Expense description"),
+     *             @OA\Property(property="amount", type="number", example=150.00, description="Expense amount"),
+     *             @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15", description="Date when expense was paid"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20", description="Due date for payment"),
+     *             @OA\Property(property="is_paid", type="boolean", example=true, description="Whether the expense is paid")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Office supplies"),
+     *             @OA\Property(property="amount", type="number", example=150.00),
+     *             @OA\Property(property="paid_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_paid", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         $expense = Expense::findOrFail($id);
@@ -59,6 +283,45 @@ class ExpenseController extends Controller
         return response()->json($expense->load('category'));
     }
 
+    /**
+     * Remove the specified expense
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/expenses/{id}",
+     *     summary="Delete an expense",
+     *     tags={"Expenses"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Expense ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Expense not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Expense not found")
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         $expense = Expense::findOrFail($id);

--- a/backend/app/Http/Controllers/Api/V1/FirstTimerController.php
+++ b/backend/app/Http/Controllers/Api/V1/FirstTimerController.php
@@ -10,10 +10,87 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @OA\Tag(
+ *     name="First Timers",
+ *     description="API Endpoints for first timer management"
+ * )
+ */
 class FirstTimerController extends Controller
 {
     /**
      * Store a new first timer or update visit count if already exists.
+     * 
+     * @OA\Post(
+     *     path="/api/v1/first-timers",
+     *     summary="Create a new first timer or update visit count",
+     *     tags={"First Timers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name","primary_mobile_number","event_id"},
+     *             @OA\Property(property="name", type="string", example="John Doe", description="First timer's full name"),
+     *             @OA\Property(property="location", type="string", example="New York", description="Location"),
+     *             @OA\Property(property="primary_mobile_number", type="string", example="+1234567890", description="Primary mobile number"),
+     *             @OA\Property(property="secondary_mobile_number", type="string", example="+0987654321", description="Secondary mobile number"),
+     *             @OA\Property(property="how_was_service", type="string", example="Great experience", description="Feedback about the service"),
+     *             @OA\Property(property="is_first_time", type="boolean", example=true, description="Is this their first time"),
+     *             @OA\Property(property="has_permanent_place_of_worship", type="boolean", example=false, description="Do they have a permanent place of worship"),
+     *             @OA\Property(property="invited_by", type="string", example="Jane Smith", description="Who invited them"),
+     *             @OA\Property(property="invited_by_member_id", type="integer", example=1, description="Member ID who invited them"),
+     *             @OA\Property(property="would_like_to_stay", type="boolean", example=true, description="Would they like to stay"),
+     *             @OA\Property(property="self_registered", type="boolean", example=false, description="Did they register themselves"),
+     *             @OA\Property(property="event_id", type="integer", example=1, description="Event ID")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="First timer registered successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="First timer registered"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="John Doe"),
+     *                 @OA\Property(property="primary_mobile_number", type="string", example="+1234567890"),
+     *                 @OA\Property(property="visit_count", type="integer", example=1),
+     *                 @OA\Property(property="status", type="string", example="first_timer"),
+     *                 @OA\Property(property="event_id", type="integer", example=1),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Visit updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Visit updated"),
+     *             @OA\Property(property="data", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=429,
+     *         description="Already registered for this event",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="First Timer already registered for this event.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request)
     {
@@ -73,6 +150,71 @@ class FirstTimerController extends Controller
 
     /**
      * Display a paginated listing of the first timers with filters.
+     * 
+     * @OA\Get(
+     *     path="/api/v1/first-timers",
+     *     summary="Get all first timers with filters",
+     *     tags={"First Timers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="event_id",
+     *         in="query",
+     *         description="Filter by event ID",
+     *         required=false,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="date",
+     *         in="query",
+     *         description="Filter by date (YYYY-MM-DD)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="search",
+     *         in="query",
+     *         description="Search by name or phone number",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="First timers retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="John Doe"),
+     *                     @OA\Property(property="primary_mobile_number", type="string", example="+1234567890"),
+     *                     @OA\Property(property="visit_count", type="integer", example=1),
+     *                     @OA\Property(property="status", type="string", example="first_timer"),
+     *                     @OA\Property(property="event_id", type="integer", example=1),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time")
+     *                 )),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=15),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request)
     {
@@ -102,6 +244,52 @@ class FirstTimerController extends Controller
 
     /**
      * Display the specified first timer.
+     * 
+     * @OA\Get(
+     *     path="/api/v1/first-timers/{id}",
+     *     summary="Get a specific first timer",
+     *     tags={"First Timers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="First timer ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="First timer retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="John Doe"),
+     *                 @OA\Property(property="primary_mobile_number", type="string", example="+1234567890"),
+     *                 @OA\Property(property="visit_count", type="integer", example=1),
+     *                 @OA\Property(property="status", type="string", example="first_timer"),
+     *                 @OA\Property(property="event_id", type="integer", example=1),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="First timer not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="First timer not found.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function show($id)
     {
@@ -114,6 +302,69 @@ class FirstTimerController extends Controller
 
     /**
      * Update the specified first timer.
+     * 
+     * @OA\Put(
+     *     path="/api/v1/first-timers/{id}",
+     *     summary="Update a first timer",
+     *     tags={"First Timers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="First timer ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="John Doe", description="First timer's full name"),
+     *             @OA\Property(property="location", type="string", example="New York", description="Location"),
+     *             @OA\Property(property="primary_mobile_number", type="string", example="+1234567890", description="Primary mobile number"),
+     *             @OA\Property(property="secondary_mobile_number", type="string", example="+0987654321", description="Secondary mobile number"),
+     *             @OA\Property(property="how_was_service", type="string", example="Great experience", description="Feedback about the service"),
+     *             @OA\Property(property="is_first_time", type="boolean", example=true, description="Is this their first time"),
+     *             @OA\Property(property="has_permanent_place_of_worship", type="boolean", example=false, description="Do they have a permanent place of worship"),
+     *             @OA\Property(property="invited_by", type="string", example="Jane Smith", description="Who invited them"),
+     *             @OA\Property(property="invited_by_member_id", type="integer", example=1, description="Member ID who invited them"),
+     *             @OA\Property(property="would_like_to_stay", type="boolean", example=true, description="Would they like to stay"),
+     *             @OA\Property(property="self_registered", type="boolean", example=false, description="Did they register themselves"),
+     *             @OA\Property(property="event_id", type="integer", example=1, description="Event ID")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="First timer updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="John Doe"),
+     *                 @OA\Property(property="primary_mobile_number", type="string", example="+1234567890"),
+     *                 @OA\Property(property="visit_count", type="integer", example=1),
+     *                 @OA\Property(property="status", type="string", example="first_timer"),
+     *                 @OA\Property(property="event_id", type="integer", example=1),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="First timer not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="First timer not found.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, $id)
     {
@@ -127,6 +378,43 @@ class FirstTimerController extends Controller
 
     /**
      * Remove the specified first timer.
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/first-timers/{id}",
+     *     summary="Delete a first timer",
+     *     tags={"First Timers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="First timer ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="First timer deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="First timer deleted.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="First timer not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="First timer not found.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function destroy($id)
     {

--- a/backend/app/Http/Controllers/Api/V1/Frontend/EventController.php
+++ b/backend/app/Http/Controllers/Api/V1/Frontend/EventController.php
@@ -7,10 +7,58 @@ use App\Models\Event;
 use Illuminate\Http\Request;
 use App\Models\EventCategory;
 
+/**
+ * @OA\Tag(
+ *     name="Frontend Events",
+ *     description="Public API Endpoints for event information (no authentication required)"
+ * )
+ */
 class EventController extends Controller
 {
     /**
      * Display the specified event category (public/guest).
+     * 
+     * @OA\Get(
+     *     path="/api/v1/frontend/event-category/{id}",
+     *     summary="Get today's events for a specific category",
+     *     tags={"Frontend Events"},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Events retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="title", type="string", example="Sunday Service"),
+     *                 @OA\Property(property="description", type="string", example="Weekly Sunday worship service"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="end_date", type="string", format="date-time"),
+     *                 @OA\Property(property="start_time", type="string", example="10:00:00"),
+     *                 @OA\Property(property="end_time", type="string", example="12:00:00"),
+     *                 @OA\Property(property="location", type="string", example="Main Auditorium"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found.")
+     *         )
+     *     )
+     * )
      */
     public function show($id)
     {

--- a/backend/app/Http/Controllers/Api/V1/Frontend/FirstTimerController.php
+++ b/backend/app/Http/Controllers/Api/V1/Frontend/FirstTimerController.php
@@ -10,9 +10,59 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
+/**
+ * @OA\Tag(
+ *     name="Frontend First Timers",
+ *     description="Public API Endpoints for first timer registration (no authentication required)"
+ * )
+ */
 class FirstTimerController extends Controller
 {
-    //get today's event based on category id and today's date
+    /**
+     * Get today's event based on category id and today's date
+     * 
+     * @OA\Get(
+     *     path="/api/v1/frontend/event-category/{categoryId}/today",
+     *     summary="Get today's event for a specific category",
+     *     tags={"Frontend First Timers"},
+     *     @OA\Parameter(
+     *         name="categoryId",
+     *         in="path",
+     *         description="Event category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Today's event retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="title", type="string", example="Sunday Service"),
+     *                 @OA\Property(property="description", type="string", example="Weekly Sunday worship service"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="end_date", type="string", format="date-time"),
+     *                 @OA\Property(property="start_time", type="string", example="10:00:00"),
+     *                 @OA\Property(property="end_time", type="string", example="12:00:00"),
+     *                 @OA\Property(property="location", type="string", example="Main Auditorium"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Event category or event not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Event category not found.")
+     *         )
+     *     )
+     * )
+     */
     public function getTodayEvent($categoryId)
     {
         $eventCategory = EventCategory::find($categoryId);
@@ -35,7 +85,91 @@ class FirstTimerController extends Controller
         ]);
     }
 
-
+    /**
+     * Create first timer guest registration
+     * 
+     * @OA\Post(
+     *     path="/api/v1/frontend/first-timer",
+     *     summary="Register a first timer guest",
+     *     tags={"Frontend First Timers"},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name", "primary_mobile_number", "event_id"},
+     *             @OA\Property(property="name", type="string", example="John Doe", description="Full name of the first timer"),
+     *             @OA\Property(property="location", type="string", example="New York", description="Location/address"),
+     *             @OA\Property(property="primary_mobile_number", type="string", example="+1234567890", description="Primary mobile number"),
+     *             @OA\Property(property="secondary_mobile_number", type="string", example="+1234567891", description="Secondary mobile number"),
+     *             @OA\Property(property="how_was_service", type="string", example="Amazing experience", description="Feedback about the service"),
+     *             @OA\Property(property="is_first_time", type="boolean", example=true, description="Whether this is their first time"),
+     *             @OA\Property(property="has_permanent_place_of_worship", type="boolean", example=false, description="Whether they have a permanent place of worship"),
+     *             @OA\Property(property="invited_by", type="string", example="Jane Smith", description="Name of person who invited them"),
+     *             @OA\Property(property="invited_by_member_id", type="integer", example=1, description="ID of member who invited them"),
+     *             @OA\Property(property="would_like_to_stay", type="boolean", example=true, description="Whether they would like to stay"),
+     *             @OA\Property(property="device_fingerprint", type="string", example="abc123", description="Device fingerprint for rate limiting"),
+     *             @OA\Property(property="self_registered", type="boolean", example=true, description="Whether they self-registered"),
+     *             @OA\Property(property="event_id", type="integer", example=1, description="Event ID they are registering for")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="First timer registered successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="First timer registered"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="John Doe"),
+     *                 @OA\Property(property="location", type="string", example="New York"),
+     *                 @OA\Property(property="primary_mobile_number", type="string", example="+1234567890"),
+     *                 @OA\Property(property="secondary_mobile_number", type="string", example="+1234567891"),
+     *                 @OA\Property(property="how_was_service", type="string", example="Amazing experience"),
+     *                 @OA\Property(property="is_first_time", type="boolean", example=true),
+     *                 @OA\Property(property="has_permanent_place_of_worship", type="boolean", example=false),
+     *                 @OA\Property(property="invited_by", type="string", example="Jane Smith"),
+     *                 @OA\Property(property="invited_by_member_id", type="integer", example=1),
+     *                 @OA\Property(property="would_like_to_stay", type="boolean", example=true),
+     *                 @OA\Property(property="device_fingerprint", type="string", example="abc123"),
+     *                 @OA\Property(property="self_registered", type="boolean", example=true),
+     *                 @OA\Property(property="event_id", type="integer", example=1),
+     *                 @OA\Property(property="visit_count", type="integer", example=1),
+     *                 @OA\Property(property="status", type="string", example="first_timer"),
+     *                 @OA\Property(property="last_submission_date", type="string", format="date"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Visit updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Visit updated"),
+     *             @OA\Property(property="data", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Self-registration not allowed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="Self-registration is only allowed on event days.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=429,
+     *         description="Rate limit exceeded or already registered",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="You have reached the maximum number of submissions for today.")
+     *         )
+     *     )
+     * )
+     */
     public function createFirstTimerGuest(Request $request)
     {
         $validator = Validator::make($request->all(), [

--- a/backend/app/Http/Controllers/Api/V1/ImportController.php
+++ b/backend/app/Http/Controllers/Api/V1/ImportController.php
@@ -10,6 +10,12 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
+/**
+ * @OA\Tag(
+ *     name="Import",
+ *     description="API Endpoints for data import functionality"
+ * )
+ */
 class ImportController extends Controller
 {
     protected $importService;
@@ -21,6 +27,78 @@ class ImportController extends Controller
 
     /**
      * Get import options and sample files
+     * 
+     * @OA\Get(
+     *     path="/api/v1/import",
+     *     summary="Get import options and sample files",
+     *     tags={"Import"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Import options retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Import system available"),
+     *             @OA\Property(property="available_imports", type="object",
+     *                 @OA\Property(property="families", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Families"),
+     *                     @OA\Property(property="description", type="string", example="Import family data with family heads"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/families"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/families"),
+     *                     @OA\Property(property="type", type="string", example="families")
+     *                 ),
+     *                 @OA\Property(property="groups", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Groups"),
+     *                     @OA\Property(property="description", type="string", example="Import group data with leaders"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/groups"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/groups"),
+     *                     @OA\Property(property="type", type="string", example="groups")
+     *                 ),
+     *                 @OA\Property(property="members", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Members"),
+     *                     @OA\Property(property="description", type="string", example="Import member data with family assignments"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/members"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/members"),
+     *                     @OA\Property(property="type", type="string", example="members")
+     *                 ),
+     *                 @OA\Property(property="event_categories", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Event Categories"),
+     *                     @OA\Property(property="description", type="string", example="Import event category data. Required fields: name, description, color, attendance_type, recurrence_pattern, weekdays"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/event_categories"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/event_categories"),
+     *                     @OA\Property(property="type", type="string", example="event_categories")
+     *                 ),
+     *                 @OA\Property(property="partnership_categories", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Partnership Categories"),
+     *                     @OA\Property(property="description", type="string", example="Import partnership category data. Required fields: name, description"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/partnership_categories"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/partnership_categories"),
+     *                     @OA\Property(property="type", type="string", example="partnership_categories")
+     *                 ),
+     *                 @OA\Property(property="income_categories", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Income Categories"),
+     *                     @OA\Property(property="description", type="string", example="Import income category data"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/income_categories"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/income_categories"),
+     *                     @OA\Property(property="type", type="string", example="income_categories")
+     *                 ),
+     *                 @OA\Property(property="expense_categories", type="object",
+     *                     @OA\Property(property="name", type="string", example="Import Expense Categories"),
+     *                     @OA\Property(property="description", type="string", example="Import expense category data"),
+     *                     @OA\Property(property="sample_file", type="string", example="http://example.com/api/v1/import/sample/expense_categories"),
+     *                     @OA\Property(property="endpoint", type="string", example="http://example.com/api/v1/import/process/expense_categories"),
+     *                     @OA\Property(property="type", type="string", example="expense_categories")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function index()
     {
@@ -82,6 +160,43 @@ class ImportController extends Controller
 
     /**
      * Download sample file for specific import type
+     * 
+     * @OA\Get(
+     *     path="/api/v1/import/sample/{type}",
+     *     summary="Download sample file for specific import type",
+     *     tags={"Import"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="type",
+     *         in="path",
+     *         description="Import type",
+     *         required=true,
+     *         @OA\Schema(type="string", enum={"families", "groups", "members", "event_categories", "partnership_categories", "income_categories", "expense_categories"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Sample file downloaded successfully",
+     *         @OA\MediaType(
+     *             mediaType="text/csv",
+     *             @OA\Schema(type="string", format="binary")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Invalid import type",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Invalid import type"),
+     *             @OA\Property(property="available_types", type="array", @OA\Items(type="string"))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function downloadSample(string $type)
     {
@@ -119,6 +234,77 @@ class ImportController extends Controller
 
     /**
      * Process import file
+     * 
+     * @OA\Post(
+     *     path="/api/v1/import/process/{type}",
+     *     summary="Process import file",
+     *     tags={"Import"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="type",
+     *         in="path",
+     *         description="Import type",
+     *         required=true,
+     *         @OA\Schema(type="string", enum={"families", "groups", "members", "event_categories", "partnership_categories", "income_categories", "expense_categories"})
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 @OA\Property(
+     *                     property="file",
+     *                     type="string",
+     *                     format="binary",
+     *                     description="Import file (CSV, XLSX, XLS)"
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Import completed successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Import completed"),
+     *             @OA\Property(property="result", type="object",
+     *                 @OA\Property(property="total_rows", type="integer", example=100),
+     *                 @OA\Property(property="success_count", type="integer", example=95),
+     *                 @OA\Property(property="skipped_count", type="integer", example=3),
+     *                 @OA\Property(property="error_count", type="integer", example=2),
+     *                 @OA\Property(property="errors", type="array", @OA\Items(type="string"))
+     *             ),
+     *             @OA\Property(property="summary", type="object",
+     *                 @OA\Property(property="total_rows", type="integer", example=100),
+     *                 @OA\Property(property="successful", type="integer", example=95),
+     *                 @OA\Property(property="skipped", type="integer", example=3),
+     *                 @OA\Property(property="errors", type="integer", example=2)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Import failed"),
+     *             @OA\Property(property="error", type="string", example="Error message")
+     *         )
+     *     )
+     * )
      */
     public function processImport(Request $request, string $type)
     {
@@ -190,6 +376,78 @@ class ImportController extends Controller
 
     /**
      * Get audit logs for imports
+     * 
+     * @OA\Get(
+     *     path="/api/v1/import/audit-logs",
+     *     summary="Get audit logs for imports",
+     *     tags={"Import"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for filtering logs (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for filtering logs (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="model_type",
+     *         in="query",
+     *         description="Filter by model type",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filter by status",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of logs per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Audit logs retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Audit logs retrieved successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="user_id", type="integer", example=1),
+     *                     @OA\Property(property="action", type="string", example="import"),
+     *                     @OA\Property(property="model_type", type="string", example="App\\Models\\Member"),
+     *                     @OA\Property(property="model_id", type="integer", example=123),
+     *                     @OA\Property(property="old_values", type="object"),
+     *                     @OA\Property(property="new_values", type="object"),
+     *                     @OA\Property(property="status", type="string", example="success"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="user", type="object")
+     *                 )),
+     *                 @OA\Property(property="meta", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function getAuditLogs(Request $request)
     {

--- a/backend/app/Http/Controllers/Api/V1/IncomeCategoryController.php
+++ b/backend/app/Http/Controllers/Api/V1/IncomeCategoryController.php
@@ -6,8 +6,58 @@ use App\Http\Controllers\Controller;
 use App\Models\IncomeCategory;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Income Categories",
+ *     description="API Endpoints for income category management"
+ * )
+ */
 class IncomeCategoryController extends Controller
 {
+    /**
+     * Display a listing of income categories
+     * 
+     * @OA\Get(
+     *     path="/api/v1/income-categories",
+     *     summary="Get all income categories",
+     *     tags={"Income Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income categories retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Sunday Offering"),
+     *                 @OA\Property(property="description", type="string", example="Sunday service offerings"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=10),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
+     */
     public function index(Request $request)
     {
         $perPage = $request->input('per_page', 10);
@@ -23,6 +73,53 @@ class IncomeCategoryController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created income category
+     * 
+     * @OA\Post(
+     *     path="/api/v1/income-categories",
+     *     summary="Create a new income category",
+     *     tags={"Income Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="Sunday Offering", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Sunday service offerings", description="Category description"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the category is active")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Income category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Sunday Offering"),
+     *             @OA\Property(property="description", type="string", example="Sunday service offerings"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -34,12 +131,117 @@ class IncomeCategoryController extends Controller
         return response()->json($category, 201);
     }
 
+    /**
+     * Display the specified income category
+     * 
+     * @OA\Get(
+     *     path="/api/v1/income-categories/{id}",
+     *     summary="Get a specific income category",
+     *     tags={"Income Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income category retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Sunday Offering"),
+     *             @OA\Property(property="description", type="string", example="Sunday service offerings"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income category not found")
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         $category = IncomeCategory::findOrFail($id);
         return response()->json($category);
     }
 
+    /**
+     * Update the specified income category
+     * 
+     * @OA\Put(
+     *     path="/api/v1/income-categories/{id}",
+     *     summary="Update an income category",
+     *     tags={"Income Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="Sunday Offering", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Sunday service offerings", description="Category description"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the category is active")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income category updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="name", type="string", example="Sunday Offering"),
+     *             @OA\Property(property="description", type="string", example="Sunday service offerings"),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         $category = IncomeCategory::findOrFail($id);
@@ -52,6 +254,45 @@ class IncomeCategoryController extends Controller
         return response()->json($category);
     }
 
+    /**
+     * Remove the specified income category
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/income-categories/{id}",
+     *     summary="Delete an income category",
+     *     tags={"Income Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income category deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income category not found")
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         $category = IncomeCategory::findOrFail($id);

--- a/backend/app/Http/Controllers/Api/V1/IncomeController.php
+++ b/backend/app/Http/Controllers/Api/V1/IncomeController.php
@@ -7,8 +7,62 @@ use App\Models\Income;
 use App\Models\IncomeCategory;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Income",
+ *     description="API Endpoints for income management"
+ * )
+ */
 class IncomeController extends Controller
 {
+    /**
+     * Display a listing of income records
+     * 
+     * @OA\Get(
+     *     path="/api/v1/incomes",
+     *     summary="Get all income records",
+     *     tags={"Income"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income records retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="description", type="string", example="Sunday offering"),
+     *                 @OA\Property(property="amount", type="number", example=2500.00),
+     *                 @OA\Property(property="received_date", type="string", format="date", example="2024-01-15"),
+     *                 @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *                 @OA\Property(property="is_received", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="category", type="object")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=10),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
+     */
     public function index(Request $request)
     {
         $perPage = $request->input('per_page', 10);
@@ -24,6 +78,60 @@ class IncomeController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created income record
+     * 
+     * @OA\Post(
+     *     path="/api/v1/incomes",
+     *     summary="Create a new income record",
+     *     tags={"Income"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"category_id","amount","received_date"},
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Income category ID"),
+     *             @OA\Property(property="description", type="string", example="Sunday offering", description="Income description"),
+     *             @OA\Property(property="amount", type="number", example=2500.00, description="Income amount"),
+     *             @OA\Property(property="received_date", type="string", format="date", example="2024-01-15", description="Date when income was received"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20", description="Due date for receipt"),
+     *             @OA\Property(property="is_received", type="boolean", example=true, description="Whether the income is received")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Income record created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Sunday offering"),
+     *             @OA\Property(property="amount", type="number", example=2500.00),
+     *             @OA\Property(property="received_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_received", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -38,12 +146,128 @@ class IncomeController extends Controller
         return response()->json($income->load('category'), 201);
     }
 
+    /**
+     * Display the specified income record
+     * 
+     * @OA\Get(
+     *     path="/api/v1/incomes/{id}",
+     *     summary="Get a specific income record",
+     *     tags={"Income"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income record ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income record retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Sunday offering"),
+     *             @OA\Property(property="amount", type="number", example=2500.00),
+     *             @OA\Property(property="received_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_received", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income record not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income record not found")
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         $income = Income::with('category')->findOrFail($id);
         return response()->json($income);
     }
 
+    /**
+     * Update the specified income record
+     * 
+     * @OA\Put(
+     *     path="/api/v1/incomes/{id}",
+     *     summary="Update an income record",
+     *     tags={"Income"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income record ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Income category ID"),
+     *             @OA\Property(property="description", type="string", example="Sunday offering", description="Income description"),
+     *             @OA\Property(property="amount", type="number", example=2500.00, description="Income amount"),
+     *             @OA\Property(property="received_date", type="string", format="date", example="2024-01-15", description="Date when income was received"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20", description="Due date for receipt"),
+     *             @OA\Property(property="is_received", type="boolean", example=true, description="Whether the income is received")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income record updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="integer", example=1),
+     *             @OA\Property(property="category_id", type="integer", example=1),
+     *             @OA\Property(property="description", type="string", example="Sunday offering"),
+     *             @OA\Property(property="amount", type="number", example=2500.00),
+     *             @OA\Property(property="received_date", type="string", format="date", example="2024-01-15"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-01-20"),
+     *             @OA\Property(property="is_received", type="boolean", example=true),
+     *             @OA\Property(property="created_at", type="string", format="date-time"),
+     *             @OA\Property(property="updated_at", type="string", format="date-time"),
+     *             @OA\Property(property="category", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income record not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income record not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         $income = Income::findOrFail($id);
@@ -59,6 +283,45 @@ class IncomeController extends Controller
         return response()->json($income->load('category'));
     }
 
+    /**
+     * Remove the specified income record
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/incomes/{id}",
+     *     summary="Delete an income record",
+     *     tags={"Income"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Income record ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income record deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Income record not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Income record not found")
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         $income = Income::findOrFail($id);

--- a/backend/app/Http/Controllers/Api/V1/PartnershipCategoryController.php
+++ b/backend/app/Http/Controllers/Api/V1/PartnershipCategoryController.php
@@ -6,8 +6,65 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\PartnershipCategory;
 
+/**
+ * @OA\Tag(
+ *     name="Partnership Categories",
+ *     description="API Endpoints for partnership category management"
+ * )
+ */
 class PartnershipCategoryController extends Controller
 {
+    /**
+     * Display a listing of partnership categories
+     * 
+     * @OA\Get(
+     *     path="/api/v1/partnership-categories",
+     *     summary="Get all partnership categories",
+     *     tags={"Partnership Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="search",
+     *         in="query",
+     *         description="Search by name or description",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership categories retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="Building Fund"),
+     *                     @OA\Property(property="description", type="string", example="Contributions for building projects"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time")
+     *                 )),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=10),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
+     */
     public function index(Request $request)
     {
         $query = PartnershipCategory::query();
@@ -20,6 +77,52 @@ class PartnershipCategoryController extends Controller
         return response()->json(['success' => true, 'data' => $categories]);
     }
 
+    /**
+     * Display the specified partnership category
+     * 
+     * @OA\Get(
+     *     path="/api/v1/partnership-categories/{id}",
+     *     summary="Get a specific partnership category",
+     *     tags={"Partnership Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership category retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Building Fund"),
+     *                 @OA\Property(property="description", type="string", example="Contributions for building projects"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Category not found")
+     *         )
+     *     )
+     * )
+     */
     public function show($id)
     {
         $category = PartnershipCategory::find($id);
@@ -29,6 +132,54 @@ class PartnershipCategoryController extends Controller
         return response()->json(['success' => true, 'data' => $category]);
     }
 
+    /**
+     * Store a newly created partnership category
+     * 
+     * @OA\Post(
+     *     path="/api/v1/partnership-categories",
+     *     summary="Create a new partnership category",
+     *     tags={"Partnership Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="Building Fund", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Contributions for building projects", description="Category description")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Partnership category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Building Fund"),
+     *                 @OA\Property(property="description", type="string", example="Contributions for building projects"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -39,6 +190,68 @@ class PartnershipCategoryController extends Controller
         return response()->json(['success' => true, 'data' => $category], 201);
     }
 
+    /**
+     * Update the specified partnership category
+     * 
+     * @OA\Put(
+     *     path="/api/v1/partnership-categories/{id}",
+     *     summary="Update a partnership category",
+     *     tags={"Partnership Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="Building Fund", description="Category name"),
+     *             @OA\Property(property="description", type="string", example="Contributions for building projects", description="Category description")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership category updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Building Fund"),
+     *                 @OA\Property(property="description", type="string", example="Contributions for building projects"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Category not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
     public function update(Request $request, $id)
     {
         $category = PartnershipCategory::find($id);
@@ -53,6 +266,46 @@ class PartnershipCategoryController extends Controller
         return response()->json(['success' => true, 'data' => $category]);
     }
 
+    /**
+     * Remove the specified partnership category
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/partnership-categories/{id}",
+     *     summary="Delete a partnership category",
+     *     tags={"Partnership Categories"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership category ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership category deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Category deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership category not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Category not found")
+     *         )
+     *     )
+     * )
+     */
     public function destroy($id)
     {
         $category = PartnershipCategory::find($id);

--- a/backend/app/Http/Controllers/Api/V1/PartnershipController.php
+++ b/backend/app/Http/Controllers/Api/V1/PartnershipController.php
@@ -10,10 +10,86 @@ use App\Models\Member;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @OA\Tag(
+ *     name="Partnerships",
+ *     description="API Endpoints for partnership management"
+ * )
+ */
 class PartnershipController extends Controller
 {
     /**
      * Display a listing of the resource.
+     * 
+     * @OA\Get(
+     *     path="/api/v1/partnerships",
+     *     summary="Get all partnerships",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="member_id",
+     *         in="query",
+     *         description="Filter by member ID",
+     *         required=false,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="category_id",
+     *         in="query",
+     *         description="Filter by category ID",
+     *         required=false,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="frequency",
+     *         in="query",
+     *         description="Filter by frequency",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"weekly","monthly","yearly","one-time"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of records per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnerships retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="member_id", type="integer", example=1),
+     *                     @OA\Property(property="category_id", type="integer", example=1),
+     *                     @OA\Property(property="pledge_amount", type="number", example=1000.00),
+     *                     @OA\Property(property="frequency", type="string", example="monthly"),
+     *                     @OA\Property(property="due_date", type="string", format="date", example="2024-12-31"),
+     *                     @OA\Property(property="start_date", type="string", format="date", example="2024-01-01"),
+     *                     @OA\Property(property="end_date", type="string", format="date", example="2024-12-31"),
+     *                     @OA\Property(property="notes", type="string", example="Building fund partnership"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="member", type="object"),
+     *                     @OA\Property(property="category", type="object")
+     *                 )),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=15),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request)
     {
@@ -33,6 +109,66 @@ class PartnershipController extends Controller
 
     /**
      * Store a newly created resource in storage.
+     * 
+     * @OA\Post(
+     *     path="/api/v1/partnerships",
+     *     summary="Create a new partnership",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"member_id","category_id","pledge_amount","frequency"},
+     *             @OA\Property(property="member_id", type="integer", example=1, description="Member ID"),
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Partnership category ID"),
+     *             @OA\Property(property="pledge_amount", type="number", example=1000.00, description="Pledge amount"),
+     *             @OA\Property(property="frequency", type="string", enum={"weekly","monthly","yearly","one-time"}, example="monthly", description="Payment frequency"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-12-31", description="Due date for one-time partnerships"),
+     *             @OA\Property(property="start_date", type="string", format="date", example="2024-01-01", description="Start date for recurring partnerships"),
+     *             @OA\Property(property="end_date", type="string", format="date", example="2024-12-31", description="End date for recurring partnerships"),
+     *             @OA\Property(property="notes", type="string", example="Building fund partnership", description="Additional notes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Partnership created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Partnership created successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="pledge_amount", type="number", example=1000.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="due_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="start_date", type="string", format="date", example="2024-01-01"),
+     *                 @OA\Property(property="end_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="notes", type="string", example="Building fund partnership"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="category", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request)
     {
@@ -64,6 +200,57 @@ class PartnershipController extends Controller
 
     /**
      * Display the specified resource.
+     * 
+     * @OA\Get(
+     *     path="/api/v1/partnerships/{id}",
+     *     summary="Get a specific partnership",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="pledge_amount", type="number", example=1000.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="due_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="start_date", type="string", format="date", example="2024-01-01"),
+     *                 @OA\Property(property="end_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="notes", type="string", example="Building fund partnership"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="category", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Partnership not found")
+     *         )
+     *     )
+     * )
      */
     public function show($id)
     {
@@ -76,6 +263,80 @@ class PartnershipController extends Controller
 
     /**
      * Update the specified resource in storage.
+     * 
+     * @OA\Put(
+     *     path="/api/v1/partnerships/{id}",
+     *     summary="Update a partnership",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="member_id", type="integer", example=1, description="Member ID"),
+     *             @OA\Property(property="category_id", type="integer", example=1, description="Partnership category ID"),
+     *             @OA\Property(property="pledge_amount", type="number", example=1000.00, description="Pledge amount"),
+     *             @OA\Property(property="frequency", type="string", enum={"weekly","monthly","yearly","one-time"}, example="monthly", description="Payment frequency"),
+     *             @OA\Property(property="due_date", type="string", format="date", example="2024-12-31", description="Due date for one-time partnerships"),
+     *             @OA\Property(property="start_date", type="string", format="date", example="2024-01-01", description="Start date for recurring partnerships"),
+     *             @OA\Property(property="end_date", type="string", format="date", example="2024-12-31", description="End date for recurring partnerships"),
+     *             @OA\Property(property="notes", type="string", example="Building fund partnership", description="Additional notes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Partnership updated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="category_id", type="integer", example=1),
+     *                 @OA\Property(property="pledge_amount", type="number", example=1000.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="due_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="start_date", type="string", format="date", example="2024-01-01"),
+     *                 @OA\Property(property="end_date", type="string", format="date", example="2024-12-31"),
+     *                 @OA\Property(property="notes", type="string", example="Building fund partnership"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="category", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Partnership not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, $id)
     {
@@ -112,6 +373,43 @@ class PartnershipController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/partnerships/{id}",
+     *     summary="Delete a partnership",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partnership deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Partnership deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Partnership not found")
+     *         )
+     *     )
+     * )
      */
     public function destroy($id)
     {
@@ -124,7 +422,46 @@ class PartnershipController extends Controller
         return response()->json(['success' => true, 'message' => 'Partnership deleted successfully']);
     }
 
-    // Additional endpoint for schedule generation (stub)
+    /**
+     * Generate schedule for a partnership
+     * 
+     * @OA\Post(
+     *     path="/api/v1/partnerships/{id}/generate-schedule",
+     *     summary="Generate payment schedule for a partnership",
+     *     tags={"Partnerships"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Partnership ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Schedule generation not yet implemented",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Schedule generation not yet implemented")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Partnership not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Partnership not found")
+     *         )
+     *     )
+     * )
+     */
     public function generateSchedule($id)
     {
         // TODO: Implement schedule generation logic based on frequency

--- a/backend/app/Http/Controllers/Api/V1/ReportsController.php
+++ b/backend/app/Http/Controllers/Api/V1/ReportsController.php
@@ -12,10 +12,88 @@ use App\Models\ExpenseCategory;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 
+/**
+ * @OA\Tag(
+ *     name="Reports",
+ *     description="API Endpoints for financial reports and analytics"
+ * )
+ */
 class ReportsController extends Controller
 {
     /**
      * Get income report data
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/income",
+     *     summary="Get income report data",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="query",
+     *         description="Filter by income category",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="query",
+     *         description="Report period",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"daily", "weekly", "monthly", "quarterly", "yearly"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Income report retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="totalIncome", type="number", format="float", example=50000.00),
+     *             @OA\Property(property="totalTransactions", type="integer", example=150),
+     *             @OA\Property(property="averageAmount", type="number", format="float", example=333.33),
+     *             @OA\Property(property="growthRate", type="string", example="+15.5%"),
+     *             @OA\Property(property="categoryBreakdown", type="array", @OA\Items(
+     *                 @OA\Property(property="category", type="string", example="Sunday Offering"),
+     *                 @OA\Property(property="amount", type="number", format="float", example=25000.00),
+     *                 @OA\Property(property="count", type="integer", example=75),
+     *                 @OA\Property(property="avgAmount", type="number", format="float", example=333.33),
+     *                 @OA\Property(property="trend", type="string", example="+12.3%")
+     *             )),
+     *             @OA\Property(property="monthlyTrends", type="array", @OA\Items(
+     *                 @OA\Property(property="month", type="string", example="Jan"),
+     *                 @OA\Property(property="total", type="number", format="float", example=8000.00),
+     *                 @OA\Property(property="sunday_offering", type="number", format="float", example=4000.00)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The end date must be a date after start date"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
      */
     public function getIncomeReport(Request $request): JsonResponse
     {
@@ -91,6 +169,80 @@ class ReportsController extends Controller
 
     /**
      * Get expense report data
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/expenses",
+     *     summary="Get expense report data",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="category",
+     *         in="query",
+     *         description="Filter by expense category",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="query",
+     *         description="Report period",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"daily", "weekly", "monthly", "quarterly", "yearly"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Expense report retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="totalExpenses", type="number", format="float", example=30000.00),
+     *             @OA\Property(property="totalBudget", type="number", format="float", example=30000.00),
+     *             @OA\Property(property="variance", type="number", format="float", example=0.00),
+     *             @OA\Property(property="averagePerMonth", type="number", format="float", example=3000.00),
+     *             @OA\Property(property="categoryBreakdown", type="array", @OA\Items(
+     *                 @OA\Property(property="category", type="string", example="Utilities"),
+     *                 @OA\Property(property="amount", type="number", format="float", example=8000.00),
+     *                 @OA\Property(property="budget", type="number", format="float", example=8000.00),
+     *                 @OA\Property(property="count", type="integer", example=12),
+     *                 @OA\Property(property="avgAmount", type="number", format="float", example=666.67),
+     *                 @OA\Property(property="trend", type="string", example="+5.2%"),
+     *                 @OA\Property(property="status", type="string", example="on_budget")
+     *             )),
+     *             @OA\Property(property="monthlyTrends", type="array", @OA\Items(
+     *                 @OA\Property(property="month", type="string", example="Jan"),
+     *                 @OA\Property(property="total", type="number", format="float", example=2500.00),
+     *                 @OA\Property(property="utilities", type="number", format="float", example=800.00)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The end date must be a date after start date"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
      */
     public function getExpenseReport(Request $request): JsonResponse
     {
@@ -172,6 +324,73 @@ class ReportsController extends Controller
 
     /**
      * Get income vs expenses comparison report
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/comparison",
+     *     summary="Get income vs expenses comparison report",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for report (Y-m-d)",
+     *         required=true,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="query",
+     *         description="Report period",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"daily", "weekly", "monthly", "quarterly", "yearly"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Comparison report retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="totalIncome", type="number", format="float", example=50000.00),
+     *             @OA\Property(property="totalExpenses", type="number", format="float", example=30000.00),
+     *             @OA\Property(property="netProfit", type="number", format="float", example=20000.00),
+     *             @OA\Property(property="profitMargin", type="number", format="float", example=40.00),
+     *             @OA\Property(property="monthlyComparison", type="array", @OA\Items(
+     *                 @OA\Property(property="month", type="string", example="Jan"),
+     *                 @OA\Property(property="income", type="number", format="float", example=8000.00),
+     *                 @OA\Property(property="expenses", type="number", format="float", example=5000.00),
+     *                 @OA\Property(property="profit", type="number", format="float", example=3000.00),
+     *                 @OA\Property(property="profitMargin", type="number", format="float", example=37.50)
+     *             )),
+     *             @OA\Property(property="categoryComparison", type="array", @OA\Items(
+     *                 @OA\Property(property="category", type="string", example="Sunday Offering"),
+     *                 @OA\Property(property="income", type="number", format="float", example=25000.00),
+     *                 @OA\Property(property="expenses", type="number", format="float", example=0.00),
+     *                 @OA\Property(property="net", type="number", format="float", example=25000.00),
+     *                 @OA\Property(property="percentage", type="number", format="float", example=50.00)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The end date must be a date after start date"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
      */
     public function getComparisonReport(Request $request): JsonResponse
     {
@@ -216,6 +435,56 @@ class ReportsController extends Controller
 
     /**
      * Export report
+     * 
+     * @OA\Post(
+     *     path="/api/v1/reports/export",
+     *     summary="Export financial report",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"reportType", "startDate", "endDate", "format"},
+     *             @OA\Property(property="reportType", type="string", enum={"comprehensive", "income", "expenses", "comparison", "budget", "custom"}, example="comprehensive", description="Type of report to export"),
+     *             @OA\Property(property="startDate", type="string", format="date", example="2024-01-01", description="Start date for report"),
+     *             @OA\Property(property="endDate", type="string", format="date", example="2024-12-31", description="End date for report"),
+     *             @OA\Property(property="format", type="string", enum={"excel", "pdf", "csv", "json"}, example="excel", description="Export format"),
+     *             @OA\Property(property="includeCharts", type="boolean", example=true, description="Include charts in export"),
+     *             @OA\Property(property="includeTables", type="boolean", example=true, description="Include tables in export")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Report exported successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="downloadUrl", type="string", example="/storage/exports/financial_report_2024.xlsx"),
+     *             @OA\Property(property="filename", type="string", example="financial_report_2024.xlsx"),
+     *             @OA\Property(property="message", type="string", example="Report exported successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The end date must be a date after start date"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="Failed to export report")
+     *         )
+     *     )
+     * )
      */
     public function exportReport(Request $request): JsonResponse
     {
@@ -405,6 +674,42 @@ class ReportsController extends Controller
 
     /**
      * Download exported report
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/download/{id}",
+     *     summary="Download exported report",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Export ID",
+     *         required=true,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Download started",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Download started"),
+     *             @OA\Property(property="fileId", type="string", example="export_123")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Export not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Export not found")
+     *         )
+     *     )
+     * )
      */
     public function downloadReport($id): JsonResponse
     {
@@ -416,6 +721,42 @@ class ReportsController extends Controller
 
     /**
      * Delete exported report
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/reports/exports/{id}",
+     *     summary="Delete exported report",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Export ID",
+     *         required=true,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Export deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Export deleted successfully"),
+     *             @OA\Property(property="fileId", type="string", example="export_123")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Export not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Export not found")
+     *         )
+     *     )
+     * )
      */
     public function deleteExport($id): JsonResponse
     {
@@ -427,6 +768,35 @@ class ReportsController extends Controller
 
     /**
      * Get export history
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/exports",
+     *     summary="Get export history",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Export history retrieved successfully",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(
+     *                 @OA\Property(property="id", type="string", example="export_123"),
+     *                 @OA\Property(property="filename", type="string", example="financial_report_2024.xlsx"),
+     *                 @OA\Property(property="type", type="string", example="comprehensive"),
+     *                 @OA\Property(property="format", type="string", example="excel"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="download_url", type="string", example="/storage/exports/financial_report_2024.xlsx")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function getExportHistory(): JsonResponse
     {
@@ -438,6 +808,36 @@ class ReportsController extends Controller
 
     /**
      * Get dashboard summary
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/dashboard-summary",
+     *     summary="Get dashboard summary",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Dashboard summary retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="totalIncome", type="number", format="float", example=8000.00),
+     *             @OA\Property(property="totalExpenses", type="number", format="float", example=5000.00),
+     *             @OA\Property(property="netProfit", type="number", format="float", example=3000.00),
+     *             @OA\Property(property="pendingPayments", type="number", format="float", example=2000.00),
+     *             @OA\Property(property="monthlyTrends", type="array", @OA\Items(
+     *                 @OA\Property(property="month", type="string", example="Jan"),
+     *                 @OA\Property(property="income", type="number", format="float", example=8000.00),
+     *                 @OA\Property(property="expenses", type="number", format="float", example=5000.00),
+     *                 @OA\Property(property="profit", type="number", format="float", example=3000.00)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function getDashboardSummary(): JsonResponse
     {
@@ -502,6 +902,31 @@ class ReportsController extends Controller
 
     /**
      * Get financial insights
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/financial-insights",
+     *     summary="Get financial insights",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Financial insights retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="topIncomeCategory", type="string", example="Sunday Offering"),
+     *             @OA\Property(property="topExpenseCategory", type="string", example="Utilities"),
+     *             @OA\Property(property="budgetVariance", type="number", format="float", example=0.00),
+     *             @OA\Property(property="growthOpportunities", type="array", @OA\Items(type="string")),
+     *             @OA\Property(property="riskFactors", type="array", @OA\Items(type="string"))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function getFinancialInsights(): JsonResponse
     {
@@ -540,6 +965,34 @@ class ReportsController extends Controller
 
     /**
      * Get recent activity
+     * 
+     * @OA\Get(
+     *     path="/api/v1/reports/recent-activity",
+     *     summary="Get recent financial activity",
+     *     tags={"Reports"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Recent activity retrieved successfully",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(
+     *                 @OA\Property(property="type", type="string", example="Income"),
+     *                 @OA\Property(property="amount", type="string", example="+$500.00"),
+     *                 @OA\Property(property="description", type="string", example="Sunday Offering received"),
+     *                 @OA\Property(property="time", type="string", example="2 hours ago"),
+     *                 @OA\Property(property="color", type="string", example="text-green-600")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     )
+     * )
      */
     public function getRecentActivity(): JsonResponse
     {

--- a/backend/app/Http/Controllers/Api/V1/RoleController.php
+++ b/backend/app/Http/Controllers/Api/V1/RoleController.php
@@ -9,10 +9,76 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @OA\Tag(
+ *     name="Roles",
+ *     description="API Endpoints for role management"
+ * )
+ */
 class RoleController extends Controller
 {
     /**
      * Display a listing of roles
+     * 
+     * @OA\Get(
+     *     path="/api/v1/roles",
+     *     summary="Get all roles",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="search",
+     *         in="query",
+     *         description="Search roles by name, display_name, or description",
+     *         required=false,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="Number of roles per page",
+     *         required=false,
+     *         @OA\Schema(type="integer", default=15)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Roles retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="admin"),
+     *                     @OA\Property(property="display_name", type="string", example="Administrator"),
+     *                     @OA\Property(property="description", type="string", example="Full system access"),
+     *                     @OA\Property(property="guard_name", type="string", example="web"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="permissions", type="array", @OA\Items(type="object"))
+     *                 )),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=15),
+     *                 @OA\Property(property="total", type="integer", example=1)
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Roles retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving roles")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request)
     {
@@ -48,6 +114,65 @@ class RoleController extends Controller
 
     /**
      * Store a newly created role
+     * 
+     * @OA\Post(
+     *     path="/api/v1/roles",
+     *     summary="Create a new role",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name","display_name"},
+     *             @OA\Property(property="name", type="string", example="editor", description="Unique role name"),
+     *             @OA\Property(property="display_name", type="string", example="Editor", description="Human-readable role name"),
+     *             @OA\Property(property="description", type="string", example="Can edit content", description="Role description"),
+     *             @OA\Property(property="permissions", type="array", @OA\Items(type="string"), example={"edit_posts","view_posts"}, description="Array of permission names")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Role created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=2),
+     *                 @OA\Property(property="name", type="string", example="editor"),
+     *                 @OA\Property(property="display_name", type="string", example="Editor"),
+     *                 @OA\Property(property="description", type="string", example="Can edit content"),
+     *                 @OA\Property(property="guard_name", type="string", example="web"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="permissions", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Role created successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error creating role")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request)
     {
@@ -102,6 +227,61 @@ class RoleController extends Controller
 
     /**
      * Display the specified role
+     * 
+     * @OA\Get(
+     *     path="/api/v1/roles/{role}",
+     *     summary="Get a specific role",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="path",
+     *         description="Role ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Role retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="admin"),
+     *                 @OA\Property(property="display_name", type="string", example="Administrator"),
+     *                 @OA\Property(property="description", type="string", example="Full system access"),
+     *                 @OA\Property(property="guard_name", type="string", example="web"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="permissions", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Role retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Role not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Role not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving role")
+     *         )
+     *     )
+     * )
      */
     public function show(Role $role)
     {
@@ -123,6 +303,87 @@ class RoleController extends Controller
 
     /**
      * Update the specified role
+     * 
+     * @OA\Put(
+     *     path="/api/v1/roles/{role}",
+     *     summary="Update a role",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="path",
+     *         description="Role ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", example="editor", description="Unique role name"),
+     *             @OA\Property(property="display_name", type="string", example="Editor", description="Human-readable role name"),
+     *             @OA\Property(property="description", type="string", example="Can edit content", description="Role description"),
+     *             @OA\Property(property="permissions", type="array", @OA\Items(type="string"), example={"edit_posts","view_posts"}, description="Array of permission names")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Role updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=2),
+     *                 @OA\Property(property="name", type="string", example="editor"),
+     *                 @OA\Property(property="display_name", type="string", example="Editor"),
+     *                 @OA\Property(property="description", type="string", example="Can edit content"),
+     *                 @OA\Property(property="guard_name", type="string", example="web"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="permissions", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Role updated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Bad request",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="System roles cannot be modified")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Role not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Role not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error updating role")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, Role $role)
     {
@@ -182,6 +443,59 @@ class RoleController extends Controller
 
     /**
      * Remove the specified role
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/roles/{role}",
+     *     summary="Delete a role",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="path",
+     *         description="Role ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Role deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Role deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Bad request",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="System roles cannot be deleted")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Role not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Role not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error deleting role")
+     *         )
+     *     )
+     * )
      */
     public function destroy(Role $role)
     {
@@ -219,6 +533,45 @@ class RoleController extends Controller
 
     /**
      * Get all permissions
+     * 
+     * @OA\Get(
+     *     path="/api/v1/roles/permissions",
+     *     summary="Get all permissions",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Permissions retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="manage_users"),
+     *                 @OA\Property(property="display_name", type="string", example="Manage Users"),
+     *                 @OA\Property(property="description", type="string", example="Can manage all users"),
+     *                 @OA\Property(property="guard_name", type="string", example="web"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Permissions retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving permissions")
+     *         )
+     *     )
+     * )
      */
     public function permissions()
     {
@@ -240,6 +593,42 @@ class RoleController extends Controller
 
     /**
      * Get role statistics
+     * 
+     * @OA\Get(
+     *     path="/api/v1/roles/statistics",
+     *     summary="Get role statistics",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Role statistics retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="total_roles", type="integer", example=5),
+     *                 @OA\Property(property="total_permissions", type="integer", example=20),
+     *                 @OA\Property(property="roles_by_user_count", type="object", example={"admin":2,"member":50}),
+     *                 @OA\Property(property="recent_roles", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Role statistics retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving role statistics")
+     *         )
+     *     )
+     * )
      */
     public function statistics()
     {
@@ -275,6 +664,61 @@ class RoleController extends Controller
 
     /**
      * Duplicate a role
+     * 
+     * @OA\Post(
+     *     path="/api/v1/roles/{role}/duplicate",
+     *     summary="Duplicate a role",
+     *     tags={"Roles"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="path",
+     *         description="Role ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Role duplicated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=3),
+     *                 @OA\Property(property="name", type="string", example="editor_copy_1234567890"),
+     *                 @OA\Property(property="display_name", type="string", example="Editor (Copy)"),
+     *                 @OA\Property(property="description", type="string", example="Can edit content (Duplicated)"),
+     *                 @OA\Property(property="guard_name", type="string", example="web"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="permissions", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Role duplicated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Role not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Role not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error duplicating role")
+     *         )
+     *     )
+     * )
      */
     public function duplicate(Role $role)
     {

--- a/backend/app/Http/Controllers/Api/V1/TitheController.php
+++ b/backend/app/Http/Controllers/Api/V1/TitheController.php
@@ -15,10 +15,101 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 use App\Models\TithePayment;
 
+/**
+ * @OA\Tag(
+ *     name="Tithes",
+ *     description="API Endpoints for tithe management"
+ * )
+ */
 class TitheController extends Controller
 {
     /**
      * Display a listing of tithes based on user role
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes",
+     *     summary="Get all tithes",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="member_id",
+     *         in="query",
+     *         description="Filter by member ID",
+     *         required=false,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filter by status",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"active", "paid", "unpaid", "overdue"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="frequency",
+     *         in="query",
+     *         description="Filter by frequency",
+     *         required=false,
+     *         @OA\Schema(type="string", enum={"weekly", "monthly"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Filter by start date (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="Filter by end date (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithes retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="member_id", type="integer", example=1),
+     *                     @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                     @OA\Property(property="frequency", type="string", example="weekly"),
+     *                     @OA\Property(property="start_date", type="string", format="date-time"),
+     *                     @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                     @OA\Property(property="is_active", type="boolean", example=true),
+     *                     @OA\Property(property="is_paid", type="boolean", example=false),
+     *                     @OA\Property(property="paid_amount", type="number", format="float", example=0.00),
+     *                     @OA\Property(property="remaining_amount", type="number", format="float", example=100.00),
+     *                     @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="member", type="object"),
+     *                     @OA\Property(property="creator", type="object")
+     *                 )),
+     *                 @OA\Property(property="meta", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithes retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving tithes")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request): JsonResponse
     {
@@ -98,6 +189,71 @@ class TitheController extends Controller
 
     /**
      * Store a newly created tithe
+     * 
+     * @OA\Post(
+     *     path="/api/v1/tithes",
+     *     summary="Create a new tithe",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"member_id", "amount", "frequency", "start_date"},
+     *             @OA\Property(property="member_id", type="integer", example=1, description="Member ID"),
+     *             @OA\Property(property="amount", type="number", format="float", example=100.00, description="Tithe amount"),
+     *             @OA\Property(property="frequency", type="string", enum={"weekly", "monthly"}, example="monthly", description="Payment frequency"),
+     *             @OA\Property(property="start_date", type="string", format="date", example="2024-01-01", description="Start date"),
+     *             @OA\Property(property="notes", type="string", example="Monthly tithe", description="Additional notes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Tithe created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=false),
+     *                 @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithe created successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error creating tithe")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request): JsonResponse
     {
@@ -159,6 +315,69 @@ class TitheController extends Controller
 
     /**
      * Display the specified tithe
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/{id}",
+     *     summary="Get a specific tithe",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithe retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=false),
+     *                 @OA\Property(property="paid_amount", type="number", format="float", example=0.00),
+     *                 @OA\Property(property="remaining_amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object"),
+     *                 @OA\Property(property="updater", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithe retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to view this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving tithe")
+     *         )
+     *     )
+     * )
      */
     public function show(Tithe $tithe): JsonResponse
     {
@@ -191,6 +410,86 @@ class TitheController extends Controller
 
     /**
      * Update the specified tithe
+     * 
+     * @OA\Put(
+     *     path="/api/v1/tithes/{id}",
+     *     summary="Update a tithe",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="amount", type="number", format="float", example=100.00, description="Tithe amount"),
+     *             @OA\Property(property="frequency", type="string", enum={"weekly", "monthly"}, example="monthly", description="Payment frequency"),
+     *             @OA\Property(property="start_date", type="string", format="date", example="2024-01-01", description="Start date"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the tithe is active"),
+     *             @OA\Property(property="notes", type="string", example="Monthly tithe", description="Additional notes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithe updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=false),
+     *                 @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object"),
+     *                 @OA\Property(property="updater", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithe updated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to update tithes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error updating tithe")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, Tithe $tithe): JsonResponse
     {
@@ -256,6 +555,85 @@ class TitheController extends Controller
 
     /**
      * Mark tithe as paid
+     * 
+     * @OA\Post(
+     *     path="/api/v1/tithes/{id}/mark-as-paid",
+     *     summary="Mark a tithe as paid",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="paid_amount", type="number", format="float", example=100.00, description="Amount paid"),
+     *             @OA\Property(property="notes", type="string", example="Payment received", description="Payment notes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithe marked as paid successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=true),
+     *                 @OA\Property(property="paid_amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="remaining_amount", type="number", format="float", example=0.00),
+     *                 @OA\Property(property="notes", type="string", example="Payment received"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object"),
+     *                 @OA\Property(property="updater", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithe marked as paid successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to access this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error marking tithe as paid")
+     *         )
+     *     )
+     * )
      */
     public function markAsPaid(Request $request, Tithe $tithe): JsonResponse
     {
@@ -314,6 +692,51 @@ class TitheController extends Controller
 
     /**
      * Remove the specified tithe
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/tithes/{id}",
+     *     summary="Delete a tithe",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithe deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Tithe deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to delete tithes")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error deleting tithe")
+     *         )
+     *     )
+     * )
      */
     public function destroy(Tithe $tithe): JsonResponse
     {
@@ -345,6 +768,63 @@ class TitheController extends Controller
 
     /**
      * Get tithe statistics
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/statistics",
+     *     summary="Get tithe statistics",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for statistics (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for statistics (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tithe statistics retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="total_tithes", type="integer", example=100),
+     *                 @OA\Property(property="active_tithes", type="integer", example=80),
+     *                 @OA\Property(property="paid_tithes", type="integer", example=60),
+     *                 @OA\Property(property="unpaid_tithes", type="integer", example=20),
+     *                 @OA\Property(property="overdue_tithes", type="integer", example=10),
+     *                 @OA\Property(property="partially_paid_tithes", type="integer", example=5),
+     *                 @OA\Property(property="total_amount", type="number", format="float", example=10000.00),
+     *                 @OA\Property(property="total_paid_amount", type="number", format="float", example=6000.00),
+     *                 @OA\Property(property="total_outstanding", type="number", format="float", example=4000.00),
+     *                 @OA\Property(property="weekly_tithes", type="integer", example=30),
+     *                 @OA\Property(property="monthly_tithes", type="integer", example=70)
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Tithe statistics retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving tithe statistics")
+     *         )
+     *     )
+     * )
      */
     public function statistics(Request $request): JsonResponse
     {
@@ -404,6 +884,60 @@ class TitheController extends Controller
 
     /**
      * Get monthly trends for tithes
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/monthly-trends",
+     *     summary="Get monthly tithe trends",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for trends (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for trends (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Monthly trends retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="period", type="string", example="Jan 2024"),
+     *                 @OA\Property(property="total_tithes", type="integer", example=25),
+     *                 @OA\Property(property="total_amount", type="number", format="float", example=2500.00),
+     *                 @OA\Property(property="total_paid", type="number", format="float", example=2000.00),
+     *                 @OA\Property(property="total_outstanding", type="number", format="float", example=500.00),
+     *                 @OA\Property(property="paid_count", type="integer", example=20),
+     *                 @OA\Property(property="unpaid_count", type="integer", example=5),
+     *                 @OA\Property(property="payment_rate", type="number", format="float", example=80.00)
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Monthly trends retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving monthly trends")
+     *         )
+     *     )
+     * )
      */
     public function monthlyTrends(Request $request): JsonResponse
     {
@@ -479,6 +1013,65 @@ class TitheController extends Controller
 
     /**
      * Get member performance analytics
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/member-performance",
+     *     summary="Get member performance analytics",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for performance analysis (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for performance analysis (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Member performance retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="member", type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="John Doe")
+     *                 ),
+     *                 @OA\Property(property="total_tithes", type="integer", example=12),
+     *                 @OA\Property(property="total_amount", type="number", format="float", example=1200.00),
+     *                 @OA\Property(property="total_paid", type="number", format="float", example=1000.00),
+     *                 @OA\Property(property="total_outstanding", type="number", format="float", example=200.00),
+     *                 @OA\Property(property="paid_count", type="integer", example=10),
+     *                 @OA\Property(property="unpaid_count", type="integer", example=2),
+     *                 @OA\Property(property="overdue_count", type="integer", example=1),
+     *                 @OA\Property(property="payment_rate", type="number", format="float", example=83.33),
+     *                 @OA\Property(property="average_amount", type="number", format="float", example=100.00)
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Member performance retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving member performance")
+     *         )
+     *     )
+     * )
      */
     public function memberPerformance(Request $request): JsonResponse
     {
@@ -543,6 +1136,70 @@ class TitheController extends Controller
 
     /**
      * Get frequency analysis
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/frequency-analysis",
+     *     summary="Get tithe frequency analysis",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         description="Start date for analysis (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         description="End date for analysis (Y-m-d)",
+     *         required=false,
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Frequency analysis retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="weekly", type="object",
+     *                     @OA\Property(property="count", type="integer", example=30),
+     *                     @OA\Property(property="total_amount", type="number", format="float", example=3000.00),
+     *                     @OA\Property(property="paid_amount", type="number", format="float", example=2500.00),
+     *                     @OA\Property(property="outstanding", type="number", format="float", example=500.00),
+     *                     @OA\Property(property="paid_count", type="integer", example=25),
+     *                     @OA\Property(property="unpaid_count", type="integer", example=5),
+     *                     @OA\Property(property="percentage", type="number", format="float", example=30.00)
+     *                 ),
+     *                 @OA\Property(property="monthly", type="object",
+     *                     @OA\Property(property="count", type="integer", example=70),
+     *                     @OA\Property(property="total_amount", type="number", format="float", example=7000.00),
+     *                     @OA\Property(property="paid_amount", type="number", format="float", example=5500.00),
+     *                     @OA\Property(property="outstanding", type="number", format="float", example=1500.00),
+     *                     @OA\Property(property="paid_count", type="integer", example=55),
+     *                     @OA\Property(property="unpaid_count", type="integer", example=15),
+     *                     @OA\Property(property="percentage", type="number", format="float", example=70.00)
+     *                 )
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Frequency analysis retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving frequency analysis")
+     *         )
+     *     )
+     * )
      */
     public function frequencyAnalysis(Request $request): JsonResponse
     {
@@ -603,6 +1260,57 @@ class TitheController extends Controller
 
     /**
      * Export tithe report
+     * 
+     * @OA\Post(
+     *     path="/api/v1/tithes/export-report",
+     *     summary="Export tithe report",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="format", type="string", enum={"excel", "pdf", "csv"}, example="excel", description="Export format"),
+     *             @OA\Property(property="type", type="string", enum={"summary", "detailed", "member_performance"}, example="summary", description="Report type"),
+     *             @OA\Property(property="start_date", type="string", format="date", example="2024-01-01", description="Start date"),
+     *             @OA\Property(property="end_date", type="string", format="date", example="2024-12-31", description="End date")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Report exported successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="file_url", type="string", example="http://example.com/storage/exports/tithe_report.xlsx"),
+     *                 @OA\Property(property="file_name", type="string", example="tithe_report.xlsx")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Report exported successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Invalid export format")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error exporting report")
+     *         )
+     *     )
+     * )
      */
     public function exportReport(Request $request): JsonResponse
     {
@@ -658,6 +1366,44 @@ class TitheController extends Controller
 
     /**
      * Get recent tithe activity
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/recent-activity",
+     *     summary="Get recent tithe activity",
+     *     tags={"Tithes"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Recent activity retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="type", type="string", example="Tithe"),
+     *                 @OA\Property(property="amount", type="string", example="$100.00"),
+     *                 @OA\Property(property="description", type="string", example="John Doe - Monthly tithe"),
+     *                 @OA\Property(property="time", type="string", example="2 hours ago"),
+     *                 @OA\Property(property="color", type="string", example="text-green-600"),
+     *                 @OA\Property(property="status", type="string", example="Paid")
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Recent activity retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving recent activity")
+     *         )
+     *     )
+     * )
      */
     public function recentActivity(Request $request): JsonResponse
     {

--- a/backend/app/Http/Controllers/Api/V1/TithePaymentController.php
+++ b/backend/app/Http/Controllers/Api/V1/TithePaymentController.php
@@ -11,10 +11,107 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @OA\Tag(
+ *     name="Tithe Payments",
+ *     description="API Endpoints for tithe payment management"
+ * )
+ */
 class TithePaymentController extends Controller
 {
     /**
      * Add a partial payment to a tithe
+     * 
+     * @OA\Post(
+     *     path="/api/v1/tithes/{tithe}/payments",
+     *     summary="Add a partial payment to a tithe",
+     *     tags={"Tithe Payments"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="tithe",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"amount", "payment_method"},
+     *             @OA\Property(property="amount", type="number", format="float", example=50.00, description="Payment amount"),
+     *             @OA\Property(property="payment_method", type="string", enum={"cash", "check", "bank_transfer", "mobile_money", "other"}, example="cash", description="Payment method"),
+     *             @OA\Property(property="reference_number", type="string", example="REF123456", description="Payment reference number"),
+     *             @OA\Property(property="notes", type="string", example="Partial payment", description="Payment notes"),
+     *             @OA\Property(property="payment_date", type="string", format="date", example="2024-01-15", description="Payment date")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Payment added successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=false),
+     *                 @OA\Property(property="paid_amount", type="number", format="float", example=50.00),
+     *                 @OA\Property(property="remaining_amount", type="number", format="float", example=50.00),
+     *                 @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object"),
+     *                 @OA\Property(property="payments", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Payment added successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Bad request",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="This tithe is already fully paid")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to access this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error adding payment")
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request, Tithe $tithe): JsonResponse
     {
@@ -96,6 +193,63 @@ class TithePaymentController extends Controller
 
     /**
      * Get payment history for a tithe
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/{tithe}/payments",
+     *     summary="Get payment history for a tithe",
+     *     tags={"Tithe Payments"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="tithe",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment history retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="tithe_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=50.00),
+     *                 @OA\Property(property="payment_method", type="string", example="cash"),
+     *                 @OA\Property(property="reference_number", type="string", example="REF123456"),
+     *                 @OA\Property(property="notes", type="string", example="Partial payment"),
+     *                 @OA\Property(property="payment_date", type="string", format="date-time"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="recorder", type="object")
+     *             )),
+     *             @OA\Property(property="message", type="string", example="Payment history retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to access this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving payment history")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request, Tithe $tithe): JsonResponse
     {
@@ -131,6 +285,78 @@ class TithePaymentController extends Controller
 
     /**
      * Get a specific payment
+     * 
+     * @OA\Get(
+     *     path="/api/v1/tithes/{tithe}/payments/{payment}",
+     *     summary="Get a specific payment",
+     *     tags={"Tithe Payments"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="tithe",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="payment",
+     *         in="path",
+     *         description="Payment ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="tithe_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=50.00),
+     *                 @OA\Property(property="payment_method", type="string", example="cash"),
+     *                 @OA\Property(property="reference_number", type="string", example="REF123456"),
+     *                 @OA\Property(property="notes", type="string", example="Partial payment"),
+     *                 @OA\Property(property="payment_date", type="string", format="date-time"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="recorder", type="object")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Payment retrieved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to access this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Payment not found for this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error retrieving payment")
+     *         )
+     *     )
+     * )
      */
     public function show(Tithe $tithe, TithePayment $payment): JsonResponse
     {
@@ -171,6 +397,125 @@ class TithePaymentController extends Controller
 
     /**
      * Update a payment
+     * 
+     * @OA\Put(
+     *     path="/api/v1/tithes/{tithe}/payments/{payment}",
+     *     summary="Update a payment",
+     *     tags={"Tithe Payments"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="tithe",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="payment",
+     *         in="path",
+     *         description="Payment ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="amount", type="number", format="float", example=50.00, description="Payment amount"),
+     *             @OA\Property(property="payment_method", type="string", enum={"cash", "check", "bank_transfer", "mobile_money", "other"}, example="cash", description="Payment method"),
+     *             @OA\Property(property="reference_number", type="string", example="REF123456", description="Payment reference number"),
+     *             @OA\Property(property="notes", type="string", example="Updated payment", description="Payment notes"),
+     *             @OA\Property(property="payment_date", type="string", format="date", example="2024-01-15", description="Payment date")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="payment", type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="tithe_id", type="integer", example=1),
+     *                     @OA\Property(property="amount", type="number", format="float", example=50.00),
+     *                     @OA\Property(property="payment_method", type="string", example="cash"),
+     *                     @OA\Property(property="reference_number", type="string", example="REF123456"),
+     *                     @OA\Property(property="notes", type="string", example="Updated payment"),
+     *                     @OA\Property(property="payment_date", type="string", format="date-time"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="recorder", type="object")
+     *                 ),
+     *                 @OA\Property(property="tithe", type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="member_id", type="integer", example=1),
+     *                     @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                     @OA\Property(property="frequency", type="string", example="monthly"),
+     *                     @OA\Property(property="start_date", type="string", format="date-time"),
+     *                     @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                     @OA\Property(property="is_active", type="boolean", example=true),
+     *                     @OA\Property(property="is_paid", type="boolean", example=false),
+     *                     @OA\Property(property="paid_amount", type="number", format="float", example=50.00),
+     *                     @OA\Property(property="remaining_amount", type="number", format="float", example=50.00),
+     *                     @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time"),
+     *                     @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                     @OA\Property(property="member", type="object"),
+     *                     @OA\Property(property="creator", type="object"),
+     *                     @OA\Property(property="payments", type="array", @OA\Items(type="object"))
+     *                 )
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Payment updated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Bad request",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="New payment amount would exceed remaining tithe amount")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to update payments")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Payment not found for this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Validation failed"),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error updating payment")
+     *         )
+     *     )
+     * )
      */
     public function update(Request $request, Tithe $tithe, TithePayment $payment): JsonResponse
     {
@@ -269,6 +614,84 @@ class TithePaymentController extends Controller
 
     /**
      * Delete a payment
+     * 
+     * @OA\Delete(
+     *     path="/api/v1/tithes/{tithe}/payments/{payment}",
+     *     summary="Delete a payment",
+     *     tags={"Tithe Payments"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="tithe",
+     *         in="path",
+     *         description="Tithe ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="payment",
+     *         in="path",
+     *         description="Payment ID",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="member_id", type="integer", example=1),
+     *                 @OA\Property(property="amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="frequency", type="string", example="monthly"),
+     *                 @OA\Property(property="start_date", type="string", format="date-time"),
+     *                 @OA\Property(property="next_due_date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="is_paid", type="boolean", example=false),
+     *                 @OA\Property(property="paid_amount", type="number", format="float", example=0.00),
+     *                 @OA\Property(property="remaining_amount", type="number", format="float", example=100.00),
+     *                 @OA\Property(property="notes", type="string", example="Monthly tithe"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="member", type="object"),
+     *                 @OA\Property(property="creator", type="object"),
+     *                 @OA\Property(property="payments", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Payment deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Unauthenticated")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Unauthorized to delete payments")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Payment not found for this tithe")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Error deleting payment")
+     *         )
+     *     )
+     * )
      */
     public function destroy(Tithe $tithe, TithePayment $payment): JsonResponse
     {


### PR DESCRIPTION
- Added @OA\Tag annotations to 15 controllers
- Documented 150+ API endpoints with detailed parameters and responses
- Added comprehensive error handling documentation
- Included request/response examples for all endpoints
- Organized endpoints into logical API tags
- Added authentication requirements for protected endpoints
- Documented both authenticated and public frontend endpoints

Controllers documented:
- RoleController, FirstTimerController, EventCategoryController
- PartnershipController, PartnershipCategoryController
- ExpenseController, IncomeController, ExpenseCategoryController, IncomeCategoryController
- TitheController, TithePaymentController, ReportsController, ImportController
- Frontend/EventController, Frontend/FirstTimerController

All API endpoints now have complete OpenAPI documentation following industry standards.